### PR TITLE
Add API original error message to #extract_rates when re-raising errors

### DIFF
--- a/lib/xe_currency/client.rb
+++ b/lib/xe_currency/client.rb
@@ -91,8 +91,8 @@ module XeCurrency
         [currency, BigDecimal(rate['mid'].to_s)]
       end
       Hash[*rates.flatten]
-    rescue StandardError
-      raise FetchError, 'Error parsing rates or adding rates to store'
+    rescue StandardError => e
+      raise FetchError, "Error parsing rates or adding rates to store: #{e.message}"
     end
 
     # @return [Hash]

--- a/lib/xe_currency/client.rb
+++ b/lib/xe_currency/client.rb
@@ -92,7 +92,7 @@ module XeCurrency
       end
       Hash[*rates.flatten]
     rescue StandardError => e
-      raise FetchError, "Error parsing rates or adding rates to store: #{e.message}"
+      raise FetchError, e.message
     end
 
     # @return [Hash]


### PR DESCRIPTION
## Context

When running `bin/createsession` on hats, a generic parsing rates error was raised from XeCurrency client. Turns out disabling SolanaPay for the merchant fixes it but the error from XeCurrency was a bit unclear to debug. This tiny PR just adds the message of the original exception to the error message for easier debugging.


